### PR TITLE
Avatar default styling

### DIFF
--- a/app/views/landingpage.scala.html
+++ b/app/views/landingpage.scala.html
@@ -184,8 +184,8 @@
                                 <tbody class="hp-optionsTable">
                                 <tr>
                                     <td>
-                                        <a class="pull-left" href="javascript:;">
-                                            <img alt="avatar" src="/assets/images/avatars/a18.png" class="hp-avatar">
+                                        <a class="pull-left undecorated" href="javascript:;">
+                                            <div class="hp-avatar-small hp-avatar-default-2">EM</div>
                                         </a>
                                     </td>
                                     <td>
@@ -389,7 +389,9 @@
 
                             <div class="well">
                                 <div class="media">
-                                    <a class="pull-left" href="javascript:;"><img alt="avatar" src="/assets/images/avatars/a1.png" class="hp-avatar"></a>
+                                    <a class="pull-left" href="javascript:;">
+                                        <div class="hp-avatar-small hp-avatar-default-0">DD</div>
+                                    </a>
                                     <div class="media-body">
                                         <h4 class="media-heading">
                                             <a href="javascript:;" data-placement="top" data-original-title="Der Dozent" data-content="Rolle: Dozent" data-delay="500" data-trigger="hover" data-html="true" rel="popover">
@@ -403,8 +405,8 @@
                                 <hr>
                                 <div class="hp-comments">
                                     <div class="media">
-                                        <a class="pull-left" href="javascript:;">
-                                            <img alt="avatar" src="/assets/images/avatars/a11.png" class="hp-avatar">
+                                        <a class="pull-left undecorated" href="javascript:;">
+                                            <div class="hp-avatar-small hp-avatar-default-4">MM</div>
                                         </a>
                                         <div class="media-body">
                                             <h5 class="media-heading">
@@ -553,7 +555,9 @@
 
                             <div class="well">
                                 <div class="media">
-                                    <a class="pull-left" href="javascript:;"><img alt="avatar" src="/assets/images/avatars/a18.png" class="hp-avatar"></a>
+                                    <a class="pull-left" href="javascript:;">
+                                        <div class="hp-avatar-small hp-avatar-default-2">EM</div>
+                                    </a>
                                     <div class="media-body">
                                         <h4 class="media-heading">
                                             <a href="javascript:;" data-placement="top" data-original-title="Erika Mustermann" data-content="Rolle: Student" data-delay="500" data-trigger="hover" data-html="true" rel="popover">
@@ -589,7 +593,9 @@
                             <br>
                             <div class="well">
                                 <div class="media">
-                                    <a class="pull-left" href="javascript:;"><img alt="avatar" src="/assets/images/avatars/a1.png" class="hp-avatar"></a>
+                                    <a class="pull-left" href="javascript:;">
+                                        <div class="hp-avatar-small hp-avatar-default-0">DD</div>
+                                    </a>
                                     <div class="media-body">
                                         <h4 class="media-heading">
                                             <a href="javascript:;" data-placement="top" data-original-title="Der Dozent" data-content="Rolle: Dozent" data-delay="500" data-trigger="hover" data-html="true" rel="popover">
@@ -605,7 +611,7 @@
                                 <div class="hp-comments">
                                     <div class="media">
                                         <a class="pull-left" href="/user/918">
-                                            <img alt="avatar" src="/assets/images/avatars/a11.png" class="hp-avatar">
+                                            <div class="hp-avatar-small hp-avatar-default-4">MM</div>
                                         </a>
                                         <div class="media-body">
                                             <h5 class="media-heading">

--- a/app/views/landingpage.scala.html
+++ b/app/views/landingpage.scala.html
@@ -184,7 +184,7 @@
                                 <tbody class="hp-optionsTable">
                                 <tr>
                                     <td>
-                                        <a class="pull-left undecorated" href="javascript:;">
+                                        <a class="pull-left hp-nohref" href="javascript:;">
                                             <div class="hp-avatar-small hp-avatar-default-2">EM</div>
                                         </a>
                                     </td>
@@ -389,7 +389,7 @@
 
                             <div class="well">
                                 <div class="media">
-                                    <a class="pull-left" href="javascript:;">
+                                    <a class="pull-left hp-nohref" href="javascript:;">
                                         <div class="hp-avatar-small hp-avatar-default-0">DD</div>
                                     </a>
                                     <div class="media-body">
@@ -405,7 +405,7 @@
                                 <hr>
                                 <div class="hp-comments">
                                     <div class="media">
-                                        <a class="pull-left undecorated" href="javascript:;">
+                                        <a class="pull-left hp-nohref" href="javascript:;">
                                             <div class="hp-avatar-small hp-avatar-default-4">MM</div>
                                         </a>
                                         <div class="media-body">
@@ -555,7 +555,7 @@
 
                             <div class="well">
                                 <div class="media">
-                                    <a class="pull-left" href="javascript:;">
+                                    <a class="pull-left hp-nohref" href="javascript:;">
                                         <div class="hp-avatar-small hp-avatar-default-2">EM</div>
                                     </a>
                                     <div class="media-body">
@@ -593,7 +593,7 @@
                             <br>
                             <div class="well">
                                 <div class="media">
-                                    <a class="pull-left" href="javascript:;">
+                                    <a class="pull-left hp-nohref" href="javascript:;">
                                         <div class="hp-avatar-small hp-avatar-default-0">DD</div>
                                     </a>
                                     <div class="media-body">
@@ -610,7 +610,7 @@
                                 <hr>
                                 <div class="hp-comments">
                                     <div class="media">
-                                        <a class="pull-left" href="/user/918">
+                                        <a class="pull-left hp-nohref" href="/user/918">
                                             <div class="hp-avatar-small hp-avatar-default-4">MM</div>
                                         </a>
                                         <div class="media-body">

--- a/app/views/snippets/userLinkAvatar.scala.html
+++ b/app/views/snippets/userLinkAvatar.scala.html
@@ -1,7 +1,7 @@
 @(user: Account)
 @import helper._
 
-<a class="pull-left undecorated" href="@if(Secured.isFriend(user)) { @routes.ProfileController.view(user.id)/stream } else { @routes.ProfileController.view(user.id) }">
+<a class="pull-left hp-nohref" href="@if(Secured.isFriend(user)) { @routes.ProfileController.view(user.id)/stream } else { @routes.ProfileController.view(user.id) }">
 	@if(user.hasAvatar){
 		<img alt="avatar" src="@routes.ProfileController.getAvatar(user.id)" class="hp-avatar-small" />
 	} else {

--- a/public/stylesheets/htwplus.css
+++ b/public/stylesheets/htwplus.css
@@ -28,10 +28,6 @@ a.disabled {
     text-decoration: line-through;
 }
 
-a.undecorated:hover {
-    text-decoration: none;
-}
-
 hr {
 	border-bottom: 1px solid #ffffff
 }

--- a/public/stylesheets/htwplus.css
+++ b/public/stylesheets/htwplus.css
@@ -1013,16 +1013,6 @@ div.hp-pagination {
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(255, 95, 0, .6);
 }
 
-.hp-avatar {
-	width: 120px;
-	height: 120px;
-}
-
-#hp-navbar .hp-avatar {
-	height: 32px;
-	width: 32px;
-}
-
 @media (max-width: 350px) {
     .hp-nav li > a {
         padding-left: 10px;
@@ -1030,27 +1020,43 @@ div.hp-pagination {
     }
 }
 
-dl .hp-avatar {
-	width: 80px;
-	height: 80px;
+table td .hp-avatar-small {
+	margin: -4px;
 }
 
-.media .hp-avatar,
-table .hp-avatar {
-	width: 25px;
-	height: 25px;
+.hp-avatar-small {
+    width: 30px;
+    height:  30px;
+    border-radius: 4px;
+	line-height: 30px;
 }
 
-table .hp-avatar {
-	margin-bottom: -4px;
-    margin-top: -4px;
+.hp-avatar-large {
+    width: 250px;
+    height: 250px;
+    border-radius: 6px;
+	line-height: 250px;
+}
+
+.hp-avatar-navi {
+    width: 32px;
+    height: 32px;
+    display: inline-block;
+    border-radius: 4px;
+	line-height: 32px;
+}
+
+.hp-avatar-medium {
+    width: 72px;
+    height: 72px;
+    border-radius: 5px;
+    display: inline-block;
+	line-height: 72px;
 }
 
 div[class*="hp-avatar-default-"] {
 	color: white;
 	text-align: center;
-	vertical-align: middle;
-    line-height: 30px;
 }
 
 div.hp-avatar-default-0 {
@@ -1091,36 +1097,6 @@ div.hp-avatar-default-8 {
 
 div.hp-avatar-default-9 {
 	background-color: rgb(95, 121, 63);
-}
-
-table td .hp-avatar-small {
-	margin: -4px;
-}
-
-.hp-avatar-small {
-    width: 30px;
-    height:  30px;
-    border-radius: 4px;
-}
-
-.hp-avatar-large {
-    width: 250px;
-    height: 250px;
-    border-radius: 6px;
-}
-
-.hp-avatar-navi {
-    width: 32px;
-    height: 32px;
-    display: inline-block;
-    border-radius: 4px;
-}
-
-.hp-avatar-medium {
-    width: 72px;
-    height: 72px;
-    border-radius: 5px;
-    display: inline-block;
 }
 
 .hp-avatar-input-wrapper {


### PR DESCRIPTION
Bei den default Avataren war etwas nicht ganz richtig mit dem vertikalen text-alignment. Die line-heights mussten angepasst werden. Außerdem wird jetzt überall einheitlich die Stylsheet-Klasse hp-nohref verwendet.